### PR TITLE
Fix topic substitution

### DIFF
--- a/zbx_ntfy.yaml
+++ b/zbx_ntfy.yaml
@@ -19,7 +19,7 @@ zabbix_export:
         - name: URL
           value: '{$NTFY.URL}'
         - name: Topic
-          value: '{$ALERT.SENDTO}'
+          value: '{ALERT.SENDTO}'
       script: |
         try {
           Zabbix.log(4, '[ ntfy Webhook ] Executed with params: ' + value);


### PR DESCRIPTION
The topic is an alert parameter and shouldn't include a dollar-sign and should simply be "{ALERT.SENDTO}" as specified on https://www.zabbix.com/documentation/current/en/manual/config/notifications/media/script