### PR TITLE
Add Cloudflare required headers

### DIFF
--- a/zbx_ntfy.yaml
+++ b/zbx_ntfy.yaml
@@ -30,6 +30,9 @@ zabbix_export:
           }
         
           var response, request = new HttpRequest();
+          // Add required headers for Cloudflare
+          request.addHeader('User-Agent: Zabbix');
+          request.addHeader('Content-Type: text/plain');
           // Check for proxy
           if (typeof params.HTTPProxy === 'string' && params.HTTPProxy.trim() !== '') {
               request.setProxy(params.HTTPProxy);


### PR DESCRIPTION
Cloudflare blocking requests without a valid User-Agent or Content-Type header. This ensures compatibility with Zabbix.